### PR TITLE
bump CNI plugins to upstream v1.1.1

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -6,6 +6,7 @@ IMAGE_NAME=rancher/flannel-cni
 VERSION=$($FLANNEL_CNI_ROOT/scripts/git-version)
 CNI_VERSION="v0.6.0"
 CNI_PLUGIN_VERSION="v1.1.1"
+FLANNEL_VERSION="v1.1.0"
 
 ARCH=amd64
 OS_TYPE=linux
@@ -35,6 +36,8 @@ esac
 mkdir -p dist
 $CURL -L --retry 5 https://github.com/containernetworking/cni/releases/download/$CNI_VERSION/cni-${ARCH}-$CNI_VERSION.tgz | tar -xz -C dist/
 $CURL -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/cni-plugins-${OS_TYPE}-${ARCH}-$CNI_PLUGIN_VERSION.tgz | tar -xz -C dist/
+$CURL -L --retry 5 https://github.com/flannel-io/cni-plugin/releases/download/$FLANNEL_VERSION/flannel-${ARCH} -o dist/flannel
+chmod +x dist/flannel
 
 case ${ARCH} in
     amd64) BASEIMAGE_ARCH="amd64" ;;

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -5,7 +5,7 @@ FLANNEL_CNI_ROOT=$(git rev-parse --show-toplevel)
 IMAGE_NAME=rancher/flannel-cni
 VERSION=$($FLANNEL_CNI_ROOT/scripts/git-version)
 CNI_VERSION="v0.6.0"
-CNI_PLUGIN_VERSION="v0.8.6"
+CNI_PLUGIN_VERSION="v1.1.1"
 
 ARCH=amd64
 OS_TYPE=linux


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/38701

Two changes:
- bump CNI plugins to upstream v1.1.1 https://github.com/containernetworking/plugins/releases/tag/v1.1.1
- pull flannel from its new repo https://github.com/flannel-io/cni-plugin/releases/tag/v1.1.0

Dev tests:
I cloned and built (`make build-image`) the image from my fork on a Unbuntu machine successfully and saw all expected binaries in the container 
```
> docker run -it f619e5e11e15 ls /opt/cni/bin/
bridge      flannel     loopback    portmap     vlan
cnitool     host-local  macvlan     ptp
dhcp        ipvlan      noop        tuning
```

for comparison, the following uses `rancher/flannel-cni:v0.3.0-rancher6 `
```
> docker run -ti rancher/flannel-cni:v0.3.0-rancher6 ls /opt/cni/bin/
bridge      flannel     loopback    portmap     vlan
cnitool     host-local  macvlan     ptp
dhcp        ipvlan      noop        tuning
```